### PR TITLE
[PR] Simplified mic implementation and added fragment support

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -13,6 +13,7 @@ repositories {
 }
 
 dependencies {
+    compile 'com.android.support:appcompat-v7:21.0.0'
     compile 'com.balysv.materialmenu:material-menu:1.5.1'
 }
  
@@ -21,7 +22,7 @@ android {
     buildToolsVersion "21.1.2"
  
     defaultConfig {
-        minSdkVersion 11
+        minSdkVersion 13
         targetSdkVersion 21
     }
  

--- a/res/layout/searchbox.xml
+++ b/res/layout/searchbox.xml
@@ -71,8 +71,6 @@
             android:layout_alignBottom="@+id/material_menu_button"
             android:layout_alignParentRight="true"
             android:layout_alignParentTop="true"
-            android:layout_toLeftOf="@+id/mic"
-            android:onClick="mic"
             android:layout_marginRight="13dp"
             android:src="@drawable/ic_action_mic" />
 


### PR DESCRIPTION
### Idea
- Be able to observe `onActivityResult` in Fragment.
- Be able to handle no mic regconition support on device. 
- Simplify mic implementation. 

### Example usage

```
public class MainFragment extends BaseFragment {

  @InjectView(R.id.searchbox)
  SearchBox mSearchBox;

  public MainFragment() {
  }

  @Override
  public View onCreateView(LayoutInflater inflater, ViewGroup container,
      Bundle savedInstanceState) {
    View view = inflater.inflate(R.layout.fragment_main, container, false);
    ButterKnife.inject(this, view);
    return view;
  }

  @Override
  public void onDestroyView() {
    super.onDestroyView();
    ButterKnife.reset(this);
  }

  @Override
  public void onViewCreated(View view, Bundle savedInstanceState) {
    super.onViewCreated(view, savedInstanceState);
    mSearchBox.setLogoText("Your logo");

    // The magic is here
    mSearchBox.enableVoiceRecognition(this);
  }

  @Override
  public void onActivityResult(int requestCode, int resultCode, Intent data) {
    if (isAdded() && requestCode == SearchBox.VOICE_RECOGNITION_CODE && resultCode == getActivity().RESULT_OK) {
      ArrayList<String> matches = data
          .getStringArrayListExtra(RecognizerIntent.EXTRA_RESULTS);
      mSearchBox.populateEditText(matches);
    }
    super.onActivityResult(requestCode, resultCode, data);
  }
}
```

` mSearchBox.enableVoiceRecognition(...)` support:
- Activity
- Fragment
- android.support.v4.app.Fragment

If you are willing to merge this PR, I will update example and documentation with you. 

Enjoy! Happy coding.