### PR TITLE
setLogoTextColor() & fix the cursor problem

### DIFF
--- a/README.md
+++ b/README.md
@@ -106,6 +106,12 @@ search.revealFromMenuItem(R.id.action_search, this);
 ```
 Note that when a search occurs, the box closes. You should react to this in onSearch, maybe set your toolbar title?
 
+## Custom
+Set the logo text color:
+```
+search.setLogoTextColor(Color.parse("#000000"));
+```
+
 ## SearchResult
 This is a class that holds two parameters - Title and icon<br />
 The title is displayed as a suggested result and will be used for searching, the icon is displayed to the left of the title in the suggestions (eg. a history icon)<br />

--- a/library/src/main/java/com/quinny898/library/persistentsearch/SearchBox.java
+++ b/library/src/main/java/com/quinny898/library/persistentsearch/SearchBox.java
@@ -498,7 +498,8 @@ public class SearchBox extends RelativeLayout {
 	 * @param text Text
 	 */
 	public void setSearchString(String text) {
-		search.setText(text);
+		search.setText("");
+		search.append(text);
 	}
 	
 	/***

--- a/library/src/main/java/com/quinny898/library/persistentsearch/SearchBox.java
+++ b/library/src/main/java/com/quinny898/library/persistentsearch/SearchBox.java
@@ -467,6 +467,15 @@ public class SearchBox extends RelativeLayout {
 		this.logoText = text;
 		setLogoTextInt(text);
 	}
+
+
+	/***
+	 * Set the text color of the logo
+	 * @param color
+	 */
+	public void setLogoTextColor(int color){
+		logo.setTextColor(color);
+	}
 	
 	/***
 	 * Set the image drawable of the drawer icon logo (do not set if you have not hidden the menu icon)


### PR DESCRIPTION
In this commit I add a setLogoTextColor() because it is sometimes necessary  to change the logo text color to another color( like secondary text color).

And I found that there is a problem when toggle the searchbox:

before:

![](http://ww3.sinaimg.cn/large/62580dd9gw1es41c0hlakg20f00qo1kx.gif)

after:

![](http://ww1.sinaimg.cn/large/62580dd9gw1es41cgd3jdg20f00qoaz5.gif)

So I use TextView.append() instead of TextView.setText() when setSearchText()