### PR TITLE
Fixes layout showing rendering problems on android studio

### DIFF
--- a/library/src/main/java/com/quinny898/library/persistentsearch/SearchBox.java
+++ b/library/src/main/java/com/quinny898/library/persistentsearch/SearchBox.java
@@ -225,8 +225,11 @@ public class SearchBox extends RelativeLayout {
 
 	private static boolean isIntentAvailable(Context context, Intent intent) {
 		PackageManager mgr = context.getPackageManager();
-		List<ResolveInfo> list = mgr.queryIntentActivities(intent, PackageManager.MATCH_DEFAULT_ONLY);
-		return list.size() > 0;
+		if (mgr != null) {
+			List<ResolveInfo> list = mgr.queryIntentActivities(intent, PackageManager.MATCH_DEFAULT_ONLY);
+			return list.size() > 0;
+		}
+		return false;
 	}
 	
 	/***


### PR DESCRIPTION
Layouts with the searchbox custom class was unable to be displayed in
android studio as it couldn't be instantiated due to NPE in SearchBox's
isIntentAvailable method. This is due to context.getPackageManager()
giving a Null result back. A simple if-else clause fixes this issue.