### PR TITLE
Various improvements to animation and live external result updating

### DIFF
--- a/library/src/main/java/com/quinny898/library/persistentsearch/SearchBox.java
+++ b/library/src/main/java/com/quinny898/library/persistentsearch/SearchBox.java
@@ -222,6 +222,16 @@ public class SearchBox extends RelativeLayout {
 
 		});
 	}
+	
+    @Override
+    public boolean onInterceptTouchEvent(MotionEvent ev) {
+        return true;
+    }
+
+    @Override
+    public boolean onTouchEvent(MotionEvent event) {
+        return search.onTouchEvent(event);
+    }
 
 	private static boolean isIntentAvailable(Context context, Intent intent) {
 		PackageManager mgr = context.getPackageManager();

--- a/library/src/main/java/com/quinny898/library/persistentsearch/SearchBox.java
+++ b/library/src/main/java/com/quinny898/library/persistentsearch/SearchBox.java
@@ -222,16 +222,6 @@ public class SearchBox extends RelativeLayout {
 
 		});
 	}
-	
-    @Override
-    public boolean onInterceptTouchEvent(MotionEvent ev) {
-        return true;
-    }
-
-    @Override
-    public boolean onTouchEvent(MotionEvent event) {
-        return search.onTouchEvent(event);
-    }
 
 	private static boolean isIntentAvailable(Context context, Intent intent) {
 		PackageManager mgr = context.getPackageManager();


### PR DESCRIPTION
Supplied search text to the onSearchTermChanged() method to allow for updating of
results shown externally during search.

Added option to disable DrawerLogo animation, allowing the retention of
the logo set in setDrawerLogo() in case the underlying view doesn't have a drawer.

Added a setDrawerLogo() method that accepts the drawable id for ease of
use.

Added a getSearchOpen() method to allow for external one-step checking.

Made hideCircularly(int x, int y, Activity activity) actually converge
on the given x and y.

Added hideCircularlyToMenuItem(int id, Activity activity) which will
converge on the menu item corresponding to the supplied id.