### PR TITLE
Fixed ClassCastException.

### DIFF
--- a/library/src/main/java/com/quinny898/library/persistentsearch/SearchBox.java
+++ b/library/src/main/java/com/quinny898/library/persistentsearch/SearchBox.java
@@ -945,7 +945,7 @@ public class SearchBox extends RelativeLayout {
     @Override
     public boolean dispatchKeyEvent(KeyEvent e) {
         if(e.getKeyCode() == KeyEvent.KEYCODE_BACK && getVisibility() == View.VISIBLE){
-            hideCircularly((Activity) getContext());
+            toggleSearch();
             return true;
         }
 


### PR DESCRIPTION
getContext() cannot always be cast to Activity as this will give a ClassCastException if it is a ContextThemeWrapper. Also, even if the hideCircularly() works, next time the search box is opened it is immediately closed as the boolean searchOpen is not being unset after hideCircularly().
