### PR TITLE
BackEventEditText

### DIFF
--- a/.idea/vcs.xml
+++ b/.idea/vcs.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <project version="4">
   <component name="VcsDirectoryMappings">
-    <mapping directory="" vcs="" />
+    <mapping directory="$PROJECT_DIR$" vcs="Git" />
   </component>
 </project>

--- a/library/src/main/java/com/quinny898/library/persistentsearch/BackEventEditText.java
+++ b/library/src/main/java/com/quinny898/library/persistentsearch/BackEventEditText.java
@@ -5,6 +5,7 @@ import android.util.AttributeSet;
 import android.view.KeyEvent;
 import android.view.inputmethod.InputMethodManager;
 import android.widget.EditText;
+import android.widget.Toast;
 
 /**
  * Created by Peter on 10/21/15.
@@ -12,6 +13,8 @@ import android.widget.EditText;
 public class BackEventEditText extends EditText {
 
     private SearchBox searchBox;
+
+    private long counter = 0;
 
     public void setSearchBox(SearchBox searchBox) {
         this.searchBox = searchBox;
@@ -34,12 +37,11 @@ public class BackEventEditText extends EditText {
     public boolean onKeyPreIme(int keyCode, KeyEvent event) {
         switch (keyCode){
             case KeyEvent.KEYCODE_BACK:
-//                InputMethodManager inputMethodManager = (InputMethodManager) getContext().getSystemService(Context.INPUT_METHOD_SERVICE);
-//                inputMethodManager.hideSoftInputFromWindow(getWindowToken(), 0);
-
-                if(searchBox != null){
+                InputMethodManager inputMethodManager = (InputMethodManager) getContext().getSystemService(Context.INPUT_METHOD_SERVICE);
+                inputMethodManager.hideSoftInputFromWindow(getApplicationWindowToken(), 0);
+                counter++;
+                if(counter % 2 != 0)
                     searchBox.closeSearch();
-                }
 
                 return true;
         }

--- a/library/src/main/java/com/quinny898/library/persistentsearch/BackEventEditText.java
+++ b/library/src/main/java/com/quinny898/library/persistentsearch/BackEventEditText.java
@@ -1,0 +1,49 @@
+package com.quinny898.library.persistentsearch;
+
+import android.content.Context;
+import android.util.AttributeSet;
+import android.view.KeyEvent;
+import android.view.inputmethod.InputMethodManager;
+import android.widget.EditText;
+
+/**
+ * Created by Peter on 10/21/15.
+ */
+public class BackEventEditText extends EditText {
+
+    private SearchBox searchBox;
+
+    public void setSearchBox(SearchBox searchBox) {
+        this.searchBox = searchBox;
+    }
+
+    public BackEventEditText(Context context) {
+        super(context);
+    }
+
+    public BackEventEditText(Context context, AttributeSet attrs) {
+        super(context, attrs);
+    }
+
+    public BackEventEditText(Context context, AttributeSet attrs, int defStyleAttr) {
+        super(context, attrs, defStyleAttr);
+    }
+
+
+    @Override
+    public boolean onKeyPreIme(int keyCode, KeyEvent event) {
+        switch (keyCode){
+            case KeyEvent.KEYCODE_BACK:
+//                InputMethodManager inputMethodManager = (InputMethodManager) getContext().getSystemService(Context.INPUT_METHOD_SERVICE);
+//                inputMethodManager.hideSoftInputFromWindow(getWindowToken(), 0);
+
+                if(searchBox != null){
+                    searchBox.closeSearch();
+                }
+
+                return true;
+        }
+
+        return super.onKeyPreIme(keyCode, event);
+    }
+}

--- a/library/src/main/java/com/quinny898/library/persistentsearch/BackEventEditText.java
+++ b/library/src/main/java/com/quinny898/library/persistentsearch/BackEventEditText.java
@@ -39,9 +39,7 @@ public class BackEventEditText extends EditText {
             case KeyEvent.KEYCODE_BACK:
                 InputMethodManager inputMethodManager = (InputMethodManager) getContext().getSystemService(Context.INPUT_METHOD_SERVICE);
                 inputMethodManager.hideSoftInputFromWindow(getApplicationWindowToken(), 0);
-                counter++;
-                if(counter % 2 != 0)
-                    searchBox.closeSearch();
+                searchBox.closeSearch();
 
                 return true;
         }

--- a/library/src/main/java/com/quinny898/library/persistentsearch/SearchBox.java
+++ b/library/src/main/java/com/quinny898/library/persistentsearch/SearchBox.java
@@ -56,7 +56,7 @@ public class SearchBox extends RelativeLayout {
 
 	private MaterialMenuView materialMenu;
 	private TextView logo;
-	private EditText search;
+	private com.quinny898.library.persistentsearch.BackEventEditText search;
 	private Context context;
 	private ListView results;
 	private ArrayList<SearchResult> resultList;
@@ -118,7 +118,8 @@ public class SearchBox extends RelativeLayout {
 		this.isMic = true;
 		this.materialMenu = (MaterialMenuView) findViewById(R.id.material_menu_button);
 		this.logo = (TextView) findViewById(R.id.logo);
-		this.search = (EditText) findViewById(R.id.search);
+		this.search = (BackEventEditText) findViewById(R.id.search);
+        search.setSearchBox(this);
 		this.results = (ListView) findViewById(R.id.results);
 		this.context = context;
 		this.pb = (ProgressBar) findViewById(R.id.pb);
@@ -844,7 +845,7 @@ public class SearchBox extends RelativeLayout {
 
 	
 
-	private void closeSearch() {
+	public void closeSearch() {
         if(animateDrawerLogo){
             this.materialMenu.animateState(IconState.BURGER);
             this.drawerLogo.setVisibility(View.VISIBLE);

--- a/library/src/main/java/com/quinny898/library/persistentsearch/SearchBox.java
+++ b/library/src/main/java/com/quinny898/library/persistentsearch/SearchBox.java
@@ -841,9 +841,7 @@ public class SearchBox extends RelativeLayout {
 		}
 	}
 
-	
 
-	
 
 	public void closeSearch() {
         if(animateDrawerLogo){
@@ -1009,4 +1007,14 @@ public class SearchBox extends RelativeLayout {
 		public boolean onFilter(SearchResult searchResult ,String searchTerm);
 	}
 
+    @Override
+    public boolean onKeyPreIme(int keyCode, KeyEvent event) {
+        switch (keyCode){
+            case KeyEvent.KEYCODE_BACK:
+                // do nothing
+                return true;
+        }
+
+        return super.onKeyPreIme(keyCode, event);
+    }
 }

--- a/library/src/main/res/layout/searchbox.xml
+++ b/library/src/main/res/layout/searchbox.xml
@@ -47,7 +47,7 @@
                 android:textColor="#212121"
                 android:textAppearance="?android:attr/textAppearanceMedium" />
 
-            <EditText
+            <com.quinny898.library.persistentsearch.BackEventEditText
                 android:id="@+id/search"
                 android:layout_width="wrap_content"
                 android:layout_height="wrap_content"
@@ -63,7 +63,7 @@
                 android:visibility="gone" >
 
                 <requestFocus />
-            </EditText>
+            </com.quinny898.library.persistentsearch.BackEventEditText>
 
             <ImageView
                 android:id="@+id/mic"


### PR DESCRIPTION
Fixed the problem where search box disappears immediately after having pressed back key to exit.

Used a custom EditText to replace EditText and re-wrote the onKeyPreIme() method.
