### PR TITLE
auto hide bug when reopen

### DIFF
--- a/library/src/main/java/com/quinny898/library/persistentsearch/SearchBox.java
+++ b/library/src/main/java/com/quinny898/library/persistentsearch/SearchBox.java
@@ -323,7 +323,8 @@ public class SearchBox extends RelativeLayout {
             @Override
             public void onAnimationEnd() {
                 setVisibility(View.GONE);
-            }
+				searchOpen = false;
+			}
 
             @Override
             public void onAnimationCancel() {


### PR DESCRIPTION
fix the bug that the SearchBox will auto hide when recall revealFromMenuItem after call hideCircularly